### PR TITLE
build obs with debug symbols, enable nixdebuginfod

### DIFF
--- a/streamdesk/default.nix
+++ b/streamdesk/default.nix
@@ -8,6 +8,15 @@
     ./companion
   ];
 
+  nix.settings = {
+    keep-derivations = true;
+    keep-outputs = true;
+    experimental-features = [
+      "nix-command"
+      "flakes"
+    ];
+  };
+
   nixpkgs.overlays = [
     (self: super: {
       decklink-sdk = super.runCommand "decklink-sdk" {
@@ -35,8 +44,12 @@
       });
     })
   ];
-  
+
+  services.nixseparatedebuginfod.enable = true;
+
   environment.systemPackages = with pkgs; [
+    gdb
+
     git
     firefox
     chromium
@@ -52,7 +65,7 @@
     mpv
     vlc
     audacity
-    
+
     pavucontrol
 
     tmux

--- a/streamdesk/obs/default.nix
+++ b/streamdesk/obs/default.nix
@@ -2,9 +2,11 @@
 {
   programs.obs-studio = {
     enable = true;
-    package = pkgs.obs-studio.override {
+    package = (pkgs.obs-studio.override {
       decklinkSupport = true;
-    };
+    }).overrideAttrs (old: {
+      cmakeBuildType = "RelWithDebInfo";
+    });
     plugins = with pkgs.obs-studio-plugins; [
       obs-source-record
       obs-webkitgtk


### PR DESCRIPTION
I *think* that’s what we need, but I am having trouble testing this deterministically 😲 